### PR TITLE
Explicitly disable update-engine and locksmithd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 EXTENSION_PREFIX            := gardener-extension
 NAME                        := os-coreos
-REGISTRY                    := eu.gcr.io/gardener-project
+REGISTRY                    := eu.gcr.io/gardener-project/gardener
 IMAGE_PREFIX                := $(REGISTRY)/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
@@ -33,7 +33,8 @@ start:
 		-mod=vendor \
 		-ldflags $(LD_FLAGS) \
 		./cmd/$(EXTENSION_PREFIX)-$(NAME) \
-		--leader-election=$(LEADER_ELECTION)
+		--leader-election=$(LEADER_ELECTION) \
+		--ignore-operation-annotation=$(IGNORE_OPERATION_ANNOTATION)
 
 #################################################################
 # Rules related to binary build, Docker image build and release #

--- a/pkg/coreos/actuator_delete.go
+++ b/pkg/coreos/actuator_delete.go
@@ -20,6 +20,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-func (c *actuator) delete(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) error {
+func (c *actuator) delete(_ context.Context, _ *extensionsv1alpha1.OperatingSystemConfig) error {
 	return nil
 }

--- a/pkg/coreos/actuator_reconcile.go
+++ b/pkg/coreos/actuator_reconcile.go
@@ -50,12 +50,14 @@ func (c *actuator) cloudConfigFromOperatingSystemConfig(ctx context.Context, con
 			},
 			Units: []Unit{
 				{
-					Name: "update-engine.service",
-					Mask: true,
+					Name:    "update-engine.service",
+					Mask:    true,
+					Command: "stop",
 				},
 				{
-					Name: "locksmithd.service",
-					Mask: true,
+					Name:    "locksmithd.service",
+					Mask:    true,
+					Command: "stop",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
The `update-engine` and `locksmithd` units are now explicitly stopped which should help in effectively preventing undesired machine reboots. See also https://github.com/coreos/docs/commit/9bdc9ddd9b52fd7700617818d8b72cfd758bee88#diff-10a5984baf88a6d8832c4f852f2b685cL77-L85

**Special notes for your reviewer**:
Thanks @kayrus for spotting 💌 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The `update-engine` and `locksmithd` units are now explicitly stopped which should help in effectively preventing undesired machine reboots.
```
