### PR TITLE
Switch to kaniko oci builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,6 +6,7 @@ gardener-extension-os-coreos:
       version:
         preprocess: 'inject-commit-hash'
       publish:
+        oci-builder: 'kaniko'
         dockerimages:
           gardener-extension-os-coreos:
             registry: 'gcr-readwrite'
@@ -41,6 +42,7 @@ gardener-extension-os-coreos:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
+          oci-builder: 'kaniko'
           dockerimages:
             gardener-extension-os-coreos:
               tag_as_latest: true


### PR DESCRIPTION
/kind enhancement

I want to try out the kaniko oci builder as according to the cicd folks it should resolved the issue with dockerhub rate limits and will allow us to remove the images that are copied in GCR currently.

As the the `.ci/pipeline_definitions` is taken from the master branch, we need first to update the pipeline_definitions and then try to adapt the base images in another PR (that will be built using the kaniko oci builder).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
