### PR TITLE
Support transmitUnencoded flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/onsi/gomega v1.10.5
 	github.com/spf13/cobra v1.1.1
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/api v0.20.7
 	k8s.io/apimachinery v0.20.7
 	k8s.io/component-base v0.20.7
+	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 

--- a/pkg/coreos/actuator_reconcile.go
+++ b/pkg/coreos/actuator_reconcile.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	actuatorUtil "github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator"
+	actuatorutil "github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
@@ -112,7 +112,7 @@ func (c *actuator) cloudConfigFromOperatingSystemConfig(ctx context.Context, con
 		}
 		f.RawFilePermissions = strconv.FormatInt(int64(permissions), 8)
 
-		rawContent, err := actuatorUtil.DataForFileContent(ctx, c.client, config.Namespace, &file.Content)
+		rawContent, err := actuatorutil.DataForFileContent(ctx, c.client, config.Namespace, &file.Content)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/coreos/actuator_test.go
+++ b/pkg/coreos/actuator_test.go
@@ -19,9 +19,9 @@ import (
 	"encoding/base64"
 
 	"github.com/gardener/gardener-extension-os-coreos/pkg/coreos"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"

--- a/pkg/coreos/actuator_test.go
+++ b/pkg/coreos/actuator_test.go
@@ -15,17 +15,84 @@
 package coreos_test
 
 import (
+	"context"
+	"encoding/base64"
+
 	"github.com/gardener/gardener-extension-os-coreos/pkg/coreos"
+	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("CloudConfig", func() {
-	var cloudConfig *coreos.CloudConfig
+	var (
+		cloudConfig *coreos.CloudConfig
+		actuator    operatingsystemconfig.Actuator
+		osc         *extensionsv1alpha1.OperatingSystemConfig
+	)
 
 	BeforeEach(func() {
 		cloudConfig = &coreos.CloudConfig{}
+		actuator = coreos.NewActuator()
+
+		osc = &extensionsv1alpha1.OperatingSystemConfig{
+			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+				Files: []extensionsv1alpha1.File{{
+					Path:        "fooPath",
+					Permissions: pointer.Int32Ptr(0666),
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "b64",
+							Data:     "YmFy",
+						},
+					},
+				}},
+			},
+		}
+	})
+
+	Describe("#Files", func() {
+
+		It("should add files to userData", func() {
+			userData, _, _, err := actuator.Reconcile(context.TODO(), osc)
+			Expect(err).To(BeNil())
+
+			expectedFiles := `write_files:
+- encoding: b64
+  content: YmFy
+  path: fooPath
+  permissions: "666"`
+			actual := string(userData)
+			Expect(actual).To(ContainSubstring(expectedFiles))
+		})
+
+		It("should return files with flag TransmitUnencoded", func() {
+			osc.Spec.Files = append(osc.Spec.Files, extensionsv1alpha1.File{
+				Path: "fooPath",
+				Content: extensionsv1alpha1.FileContent{
+					TransmitUnencoded: pointer.BoolPtr(true),
+					Inline: &extensionsv1alpha1.FileContentInline{
+						Encoding: "b64",
+						Data:     base64.StdEncoding.EncodeToString([]byte("bar")),
+					},
+				}})
+			userData, _, _, err := actuator.Reconcile(context.TODO(), osc)
+			Expect(err).To(BeNil())
+
+			expectedFiles := `write_files:
+- encoding: b64
+  content: YmFy
+  path: fooPath
+  permissions: "666"
+- content: bar
+  path: fooPath`
+			actual := string(userData)
+			Expect(actual).To(ContainSubstring(expectedFiles))
+		})
+
 	})
 
 	Describe("#String", func() {

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
+	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Actuator uses a generator to render an OperatingSystemConfiguration for an Operating System
+type Actuator struct {
+	scheme    *runtime.Scheme
+	client    client.Client
+	logger    logr.Logger
+	osName    string
+	generator generator.Generator
+}
+
+// NewActuator creates a new actuator with the given logger.
+func NewActuator(osName string, generator generator.Generator) operatingsystemconfig.Actuator {
+	return &Actuator{
+		logger:    log.Log.WithName(osName + "-operatingsystemconfig-actuator"),
+		osName:    osName,
+		generator: generator,
+	}
+}
+
+// InjectScheme injects a runtime Scheme to the Actuator
+func (a *Actuator) InjectScheme(scheme *runtime.Scheme) error {
+	a.scheme = scheme
+	return nil
+}
+
+// InjectClient injects a Client to the Actuator
+func (a *Actuator) InjectClient(client client.Client) error {
+	a.client = client
+	return nil
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_delete.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_delete.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Delete ignores the deletion of OperatingSystemConfig
+func (a *Actuator) Delete(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) error {
+	return nil
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_migrate.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_migrate.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Migrate ignores the deletion of OperatingSystemConfig
+func (a *Actuator) Migrate(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) error {
+	return nil
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+	"fmt"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Reconcile reconciles the update of a OperatingSystemConfig regenerating the os-specific format
+func (a *Actuator) Reconcile(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
+	cloudConfig, cmd, err := CloudConfigFromOperatingSystemConfig(ctx, a.client, config, a.generator)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("could not generate cloud config: %v", err)
+	}
+
+	return cloudConfig, cmd, OperatingSystemConfigUnitNames(config), nil
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_restore.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_restore.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Restore reconciles the update of a OperatingSystemConfig regenerating the os-specific format
+func (a *Actuator) Restore(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
+	return a.Reconcile(ctx, config)
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
+	commonosgenerator "github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CloudConfigFromOperatingSystemConfig generates a CloudConfig from an OperatingSystemConfig
+// using a Generator
+func CloudConfigFromOperatingSystemConfig(ctx context.Context, c client.Client, config *extensionsv1alpha1.OperatingSystemConfig, generator commonosgenerator.Generator) ([]byte, *string, error) {
+	files := make([]*commonosgenerator.File, 0, len(config.Spec.Files))
+	for _, file := range config.Spec.Files {
+		data, err := DataForFileContent(ctx, c, config.Namespace, &file.Content)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		files = append(files, &commonosgenerator.File{Path: file.Path, Content: data, Permissions: file.Permissions, TransmitUnencoded: file.Content.TransmitUnencoded})
+	}
+
+	units := make([]*commonosgenerator.Unit, 0, len(config.Spec.Units))
+	for _, unit := range config.Spec.Units {
+		var content []byte
+		if unit.Content != nil {
+			content = []byte(*unit.Content)
+		}
+
+		dropIns := make([]*commonosgenerator.DropIn, 0, len(unit.DropIns))
+		for _, dropIn := range unit.DropIns {
+			dropIns = append(dropIns, &commonosgenerator.DropIn{Name: dropIn.Name, Content: []byte(dropIn.Content)})
+		}
+		units = append(units, &commonosgenerator.Unit{Name: unit.Name, Content: content, DropIns: dropIns})
+	}
+
+	return generator.Generate(&commonosgenerator.OperatingSystemConfig{
+		Object:    config,
+		Bootstrap: config.Spec.Purpose == extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
+		CRI:       config.Spec.CRIConfig,
+		Files:     files,
+		Units:     units,
+		Path:      config.Spec.ReloadConfigFilePath,
+	})
+}
+
+// DataForFileContent returns the content for a FileContent, retrieving from a Secret if necessary.
+func DataForFileContent(ctx context.Context, c client.Client, namespace string, content *extensionsv1alpha1.FileContent) ([]byte, error) {
+	if inline := content.Inline; inline != nil {
+		if len(inline.Encoding) == 0 {
+			return []byte(inline.Data), nil
+		}
+		return cloudinit.Decode(inline.Encoding, []byte(inline.Data))
+	}
+
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, kutil.Key(namespace, content.SecretRef.Name), secret); err != nil {
+		return nil, err
+	}
+
+	return secret.Data[content.SecretRef.DataKey], nil
+}
+
+// OperatingSystemConfigUnitNames returns the names of the units in the OperatingSystemConfig
+func OperatingSystemConfigUnitNames(config *extensionsv1alpha1.OperatingSystemConfig) []string {
+	unitNames := make([]string, 0, len(config.Spec.Units))
+	for _, unit := range config.Spec.Units {
+		unitNames = append(unitNames, unit.Name)
+	}
+	return unitNames
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit/cloudinit.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit/cloudinit.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudinit
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// FileCodecID is the id of a FileCodec for cloud-init scripts.
+type FileCodecID string
+
+const (
+	// B64FileCodecID is the base64 file codec id.
+	B64FileCodecID FileCodecID = "b64"
+	// GZIPFileCodecID is the gzip file codec id.
+	GZIPFileCodecID FileCodecID = "gzip"
+	// GZIPB64FileCodecID is the gzip combined with base64 codec id.
+	GZIPB64FileCodecID FileCodecID = "gzip+b64"
+)
+
+var validFileCodecIDs = map[FileCodecID]struct{}{
+	B64FileCodecID:     {},
+	GZIPFileCodecID:    {},
+	GZIPB64FileCodecID: {},
+}
+
+// FileCodec is a codec to en- and decode data in cloud-init scripts with.j
+type FileCodec interface {
+	Encode([]byte) ([]byte, error)
+	Decode([]byte) ([]byte, error)
+}
+
+var (
+	// B64FileCodec is the base64 FileCodec.
+	B64FileCodec FileCodec = b64FileCodec{}
+	// GZIPFileCodec is the gzip FileCodec.
+	GZIPFileCodec FileCodec = gzipFileCodec{}
+)
+
+type b64FileCodec struct{}
+
+var encoding = base64.StdEncoding
+
+func (b64FileCodec) Encode(data []byte) ([]byte, error) {
+	dst := make([]byte, encoding.EncodedLen(len(data)))
+	encoding.Encode(dst, data)
+	return dst, nil
+}
+
+func (b64FileCodec) Decode(data []byte) ([]byte, error) {
+	dst := make([]byte, encoding.DecodedLen(len(data)))
+	n, err := encoding.Decode(dst, data)
+	return dst[:n], err
+}
+
+type gzipFileCodec struct{}
+
+func (gzipFileCodec) Encode(data []byte) ([]byte, error) {
+	var out bytes.Buffer
+	w := gzip.NewWriter(&out)
+	if _, err := w.Write(data); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func (gzipFileCodec) Decode(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	return io.ReadAll(r)
+}
+
+// ParseFileCodecID tries to parse a string into a FileCodecID.
+func ParseFileCodecID(s string) (FileCodecID, error) {
+	id := FileCodecID(s)
+	if _, ok := validFileCodecIDs[id]; !ok {
+		return id, fmt.Errorf("invalid file codec id %q", id)
+	}
+	return id, nil
+}
+
+var fileCodecIDToFileCodec = map[FileCodecID]FileCodec{
+	B64FileCodecID:  B64FileCodec,
+	GZIPFileCodecID: GZIPFileCodec,
+}
+
+// FileCodecForID retrieves the FileCodec for the given FileCodecID.
+func FileCodecForID(id FileCodecID) FileCodec {
+	return fileCodecIDToFileCodec[id]
+}
+
+// Decode decodes the given data using the codec from resolving the given codecIDString.
+// It's a shorthand for parsing the FileCodecID and calling the `Decode` method on the obtained
+// FileCodec.
+func Decode(codecIDString string, data []byte) ([]byte, error) {
+	id, err := ParseFileCodecID(codecIDString)
+	if err != nil {
+		return nil, err
+	}
+
+	return FileCodecForID(id).Decode(data)
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/generator.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/generator.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Generator renders an OperatingSystemConfig into a
+// representation suitable for an specific OS
+// also returns the os specific command for applying this configuration
+type Generator interface {
+	Generate(*OperatingSystemConfig) (osconfig []byte, command *string, err error)
+}
+
+// File is a file to be stored during the cloud init script.
+type File struct {
+	Path              string
+	Content           []byte
+	Permissions       *int32
+	TransmitUnencoded *bool
+}
+
+// Unit is a unit to be created during the cloud init script.
+type Unit struct {
+	Name    string
+	Content []byte
+	DropIns []*DropIn
+}
+
+// DropIn is a drop in of a Unit.
+type DropIn struct {
+	Name    string
+	Content []byte
+}
+
+// OperatingSystemConfig is the data required to create a cloud init script.
+type OperatingSystemConfig struct {
+	Object    *extensionsv1alpha1.OperatingSystemConfig
+	CRI       *extensionsv1alpha1.CRIConfig
+	Files     []*File
+	Units     []*Unit
+	Bootstrap bool
+	Path      *string
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,6 +43,9 @@ github.com/gardener/gardener/extensions/pkg/controller
 github.com/gardener/gardener/extensions/pkg/controller/cmd
 github.com/gardener/gardener/extensions/pkg/controller/error
 github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig
+github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator
+github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit
+github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator
 github.com/gardener/gardener/extensions/pkg/inject
 github.com/gardener/gardener/extensions/pkg/log
 github.com/gardener/gardener/extensions/pkg/predicate
@@ -457,7 +460,6 @@ istio.io/client-go/pkg/apis/networking/v1beta1
 # istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a
 istio.io/gogo-genproto/googleapis/google/api
 # k8s.io/api v0.20.7 => k8s.io/api v0.20.7
-## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -737,6 +739,7 @@ k8s.io/kube-openapi/pkg/generators/rules
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/sets
 # k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer


### PR DESCRIPTION
Accepts the flag `Transmit Unencoded`.

Needed for creation of bootstrap-tokens for machines introduced here: https://github.com/gardener/gardener/pull/3902

**How to categorize this PR?**
/area security
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/3898 and https://github.com/gardener/gardener/pull/3902

**Release note**:
```other operator
Introduces new flag `TransmitUnencoded` which writes file content unencoded into the worker resource.
```