### PR TITLE
Enable support for containerd

### DIFF
--- a/pkg/coreos/actuator_reconcile.go
+++ b/pkg/coreos/actuator_reconcile.go
@@ -153,6 +153,8 @@ WantedBy=containerd.service kubelet.service
 `,
 			})
 
+		unitNames = append(unitNames, "run-command.service")
+
 		cloudConfig.WriteFiles = append(
 			cloudConfig.WriteFiles,
 			File{

--- a/pkg/coreos/templates/containerd/run-command.sh.tpl
+++ b/pkg/coreos/templates/containerd/run-command.sh.tpl
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# initiliaze default containerd config if does not exist
+if [ ! -s /etc/containerd/config.toml ]; then
+    mkdir -p /etc/containerd/
+    /run/torcx/unpack/docker/bin/containerd config default > /etc/containerd/config.toml
+    chmod 0644 /etc/containerd/config.toml
+fi
+
+# provide kubelet with access to the containerd binaries in /run/torcx/unpack/docker/bin
+if [ ! -s /etc/systemd/system/kubelet.service.d/environment.conf ]; then
+    mkdir -p /etc/systemd/system/kubelet.service.d/
+    cat <<EOF | tee /etc/systemd/system/kubelet.service.d/environment.conf
+[Service]
+Environment="PATH=/run/torcx/unpack/docker/bin:$PATH"
+EOF
+    chmod 0644 /etc/systemd/system/kubelet.service.d/environment.conf
+    systemctl daemon-reload
+fi

--- a/pkg/coreos/types.go
+++ b/pkg/coreos/types.go
@@ -22,6 +22,8 @@ import (
 
 // CloudConfig is a structure containing the relevant fields for generating the Config
 // Container Linux specific cloud config. It can be marshalled to YAML.
+// Note, Flatcar cloud config does not support `runcmd`, see https://github.com/kinvolk/coreos-cloudinit/blob/flatcar-master/Documentation/cloud-config.md#file-format
+// Therefore, do not try to implement runcmd.
 type CloudConfig struct {
 	// Config contains CoreOS specific configuration.
 	CoreOS Config `yaml:"coreos,omitempty"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
Enable support for containerd.

**Which issue(s) this PR fixes**:
Fixes #26 

**Special notes for your reviewer**:
The usual bin directories  `/bin`, `/usr/bin` and `/usr/loca/bin` in Flatcar are read-only, therefore it is not possible to place symbolic links there to the containerd binaries which are installed in `/run/torcx/unpack/docker/bin`. Therefore this extension adds `/run/torcx/unpack/docker/bin` to the PATH in the containerd and kubelet environment.

As there is no support for `runcmd` in CoreOS/Flatcar, this behavior is achieved via a oneshot systemd service.

I have created an AWS 1.18.20 shoot cluster and run successfully several times the conformance tests from https://github.com/gardener/test-infra/blob/master/integration-tests/e2e/README.md.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
This extension now supports containerd as container runtime interface for Flatcar OS. Landscape operators needs to explicitly allow containerd in their cloudprofiles so that the shoot owners can later configure it in the worker pools of their shoot clusters.
```
