### PR TITLE
Compatibility with logrotate in /usr/bin

### DIFF
--- a/pkg/coreos/actuator_test.go
+++ b/pkg/coreos/actuator_test.go
@@ -125,6 +125,8 @@ var _ = Describe("CloudConfig", func() {
 
     CONTAINERD_CONFIG=/etc/containerd/config.toml
 
+    ALTERNATE_LOGROTATE_PATH="/usr/bin/logrotate"
+
     # initialize default containerd config if does not exist
     if [ ! -s "$CONTAINERD_CONFIG" ]; then
         mkdir -p /etc/containerd/
@@ -145,6 +147,12 @@ var _ = Describe("CloudConfig", func() {
     Environment="PATH=/run/torcx/unpack/docker/bin:$PATH"
     EOF
         chmod 0644 /etc/systemd/system/kubelet.service.d/environment.conf
+        systemctl daemon-reload
+    fi
+
+    # some flatcar versions have logrotate at /usr/bin instead of /usr/sbin
+    if [ -f "$ALTERNATE_LOGROTATE_PATH" ]; then
+        sed -i "s;/usr/sbin/logrotate;$ALTERNATE_LOGROTATE_PATH;" /etc/systemd/system/containerd-logrotate.service
         systemctl daemon-reload
     fi
   path: /opt/bin/run-command.sh

--- a/pkg/coreos/templates/containerd/run-command.sh.tpl
+++ b/pkg/coreos/templates/containerd/run-command.sh.tpl
@@ -2,6 +2,8 @@
 
 CONTAINERD_CONFIG=/etc/containerd/config.toml
 
+ALTERNATE_LOGROTATE_PATH="/usr/bin/logrotate"
+
 # initialize default containerd config if does not exist
 if [ ! -s "$CONTAINERD_CONFIG" ]; then
     mkdir -p /etc/containerd/
@@ -22,5 +24,11 @@ if [ ! -s /etc/systemd/system/kubelet.service.d/environment.conf ]; then
 Environment="PATH=/run/torcx/unpack/docker/bin:$PATH"
 EOF
     chmod 0644 /etc/systemd/system/kubelet.service.d/environment.conf
+    systemctl daemon-reload
+fi
+
+# some flatcar versions have logrotate at /usr/bin instead of /usr/sbin
+if [ -f "$ALTERNATE_LOGROTATE_PATH" ]; then
+    sed -i "s;/usr/sbin/logrotate;$ALTERNATE_LOGROTATE_PATH;" /etc/systemd/system/containerd-logrotate.service
     systemctl daemon-reload
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:

Recent flatcar images has the logrotate binary not in `/usr/sbin` anymore, but in `/usr/bin`. Thus this PR extends the `run-command.service` (doing Containerd & Flatcar / Core OS related patches) to check for the alternate location of logrotate. If it finds the binary under `/usr/bin` it patches the path in `/etc/systemd/system/containerd-logrotate.service`.

**Which issue(s) this PR fixes**:
Fixes #54

**Special notes for your reviewer**: -

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
bugfix user 
fixes containerd-lograte unit for Flatcar images with logrotate in /usr/bin
```
