### PR TITLE
Support flatcar version >= 3815.2.0

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -98,9 +98,11 @@ if [ ! -s /etc/containerd/config.toml ]; then
 fi
 mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+# remove this file once flatcar versions that use torcx are no longer supported
 [Service]
 ExecStart=
-ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" /run/torcx/unpack/docker/bin/containerd --config /etc/containerd/config.toml'
+# try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'
 EOF
 chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 ` + writeFilesToDiskScript + `

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -65,9 +65,11 @@ if [ ! -s /etc/containerd/config.toml ]; then
 fi
 mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+# remove this file once flatcar versions that use torcx are no longer supported
 [Service]
 ExecStart=
-ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" /run/torcx/unpack/docker/bin/containerd --config /etc/containerd/config.toml'
+# try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'
 EOF
 chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 
@@ -87,10 +89,17 @@ CONTAINERD_CONFIG=/etc/containerd/config.toml
 
 ALTERNATE_LOGROTATE_PATH="/usr/bin/logrotate"
 
+# prefer containerd from torcx. Remove this special case once all flatcar versions
+# that use torcx have run out of support
+CONTAINERD="/usr/bin/containerd"
+if [ -x /run/torcx/unpack/docker/bin/containerd ]; then
+    CONTAINERD="/run/torcx/unpack/docker/bin/containerd"
+fi
+
 # initialize default containerd config if does not exist
 if [ ! -s "$CONTAINERD_CONFIG" ]; then
-    mkdir -p /etc/containerd/
-    /run/torcx/unpack/docker/bin/containerd config default > "$CONTAINERD_CONFIG"
+    mkdir -p "$(dirname "$CONTAINERD_CONFIG")"
+    ${CONTAINERD} config default > "$CONTAINERD_CONFIG"
     chmod 0644 "$CONTAINERD_CONFIG"
 fi
 
@@ -99,6 +108,7 @@ if [[ -e /sys/fs/cgroup/cgroup.controllers ]]; then
     sed -i "s/SystemdCgroup *= *false/SystemdCgroup = true/" "$CONTAINERD_CONFIG"
 fi
 
+# Remove this block once all flatcar versions that use torcx have run out of support
 # provide kubelet with access to the containerd binaries in /run/torcx/unpack/docker/bin
 if [ ! -s /etc/systemd/system/kubelet.service.d/environment.conf ]; then
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/controller/operatingsystemconfig/coreos_reconcile.go
+++ b/pkg/controller/operatingsystemconfig/coreos_reconcile.go
@@ -161,10 +161,12 @@ WantedBy=containerd.service kubelet.service
 			coreos.File{
 				Path:               "/etc/systemd/system/containerd.service.d/11-exec_config.conf",
 				RawFilePermissions: "0644",
-				Content: `[Service]
+				Content: `# remove this file once flatcar versions that use torcx are no longer supported
+[Service]
 SyslogIdentifier=containerd
 ExecStart=
-ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" /run/torcx/unpack/docker/bin/containerd --config /etc/containerd/config.toml'
+# try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'
 `,
 			},
 			coreos.File{

--- a/pkg/controller/operatingsystemconfig/coreos_reconcile_test.go
+++ b/pkg/controller/operatingsystemconfig/coreos_reconcile_test.go
@@ -127,10 +127,12 @@ var _ = Describe("CloudConfig", func() {
 
 			expectedFiles := `write_files:
 - content: |
+    # remove this file once flatcar versions that use torcx are no longer supported
     [Service]
     SyslogIdentifier=containerd
     ExecStart=
-    ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" /run/torcx/unpack/docker/bin/containerd --config /etc/containerd/config.toml'
+    # try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+    ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'
   path: /etc/systemd/system/containerd.service.d/11-exec_config.conf
   permissions: "0644"
 - content: |
@@ -140,10 +142,17 @@ var _ = Describe("CloudConfig", func() {
 
     ALTERNATE_LOGROTATE_PATH="/usr/bin/logrotate"
 
+    # prefer containerd from torcx. Remove this special case once all flatcar versions
+    # that use torcx have run out of support
+    CONTAINERD="/usr/bin/containerd"
+    if [ -x /run/torcx/unpack/docker/bin/containerd ]; then
+        CONTAINERD="/run/torcx/unpack/docker/bin/containerd"
+    fi
+
     # initialize default containerd config if does not exist
     if [ ! -s "$CONTAINERD_CONFIG" ]; then
-        mkdir -p /etc/containerd/
-        /run/torcx/unpack/docker/bin/containerd config default > "$CONTAINERD_CONFIG"
+        mkdir -p "$(dirname "$CONTAINERD_CONFIG")"
+        ${CONTAINERD} config default > "$CONTAINERD_CONFIG"
         chmod 0644 "$CONTAINERD_CONFIG"
     fi
 
@@ -152,6 +161,7 @@ var _ = Describe("CloudConfig", func() {
         sed -i "s/SystemdCgroup *= *false/SystemdCgroup = true/" "$CONTAINERD_CONFIG"
     fi
 
+    # Remove this block once all flatcar versions that use torcx have run out of support
     # provide kubelet with access to the containerd binaries in /run/torcx/unpack/docker/bin
     if [ ! -s /etc/systemd/system/kubelet.service.d/environment.conf ]; then
         mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/controller/operatingsystemconfig/templates/containerd/run-command.sh.tpl
+++ b/pkg/controller/operatingsystemconfig/templates/containerd/run-command.sh.tpl
@@ -4,10 +4,17 @@ CONTAINERD_CONFIG=/etc/containerd/config.toml
 
 ALTERNATE_LOGROTATE_PATH="/usr/bin/logrotate"
 
+# prefer containerd from torcx. Remove this special case once all flatcar versions
+# that use torcx have run out of support
+CONTAINERD="/usr/bin/containerd"
+if [ -x /run/torcx/unpack/docker/bin/containerd ]; then
+    CONTAINERD="/run/torcx/unpack/docker/bin/containerd"
+fi
+
 # initialize default containerd config if does not exist
 if [ ! -s "$CONTAINERD_CONFIG" ]; then
-    mkdir -p /etc/containerd/
-    /run/torcx/unpack/docker/bin/containerd config default > "$CONTAINERD_CONFIG"
+    mkdir -p "$(dirname "$CONTAINERD_CONFIG")"
+    ${CONTAINERD} config default > "$CONTAINERD_CONFIG"
     chmod 0644 "$CONTAINERD_CONFIG"
 fi
 
@@ -16,6 +23,7 @@ if [[ -e /sys/fs/cgroup/cgroup.controllers ]]; then
     sed -i "s/SystemdCgroup *= *false/SystemdCgroup = true/" "$CONTAINERD_CONFIG"
 fi
 
+# Remove this block once all flatcar versions that use torcx have run out of support
 # provide kubelet with access to the containerd binaries in /run/torcx/unpack/docker/bin
 if [ ! -s /etc/systemd/system/kubelet.service.d/environment.conf ]; then
     mkdir -p /etc/systemd/system/kubelet.service.d/


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:

Flatcar starting from version 3815.2.0 has removed torcx support and replaced it with [systemd-sysext](https://www.flatcar.org/docs/latest/provisioning/sysext/). The main difference form a user perspective is that the containerd binaries have moved from /run/torcx/unpack/docker/bin to /usr/bin .

This PR updates the extension to (still) prefer binaries in /run/torcx/unpack/docker/bin but to also fall back to /usr/bin if the former don't exit. This allows using both Flatcar versions that still use torcx and those that only use systemd-sysext.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I've manually tested the change with flatcar 3760.2.0 and 3815.2.0. (although still using Gardener 1.79)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
feature The extension now also supports Flatcar image with version 3815.2.0 .
```
