### PR TITLE
Add codeowners from STACKIT

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # gardener-extension-os-coreos maintainers
-*   @gardener/gardener-extension-os-coreos-maintainers @gardener/gardener-maintainers
+* @dergeberl @timebertt @gardener/gardener-extension-os-coreos-maintainers @gardener/gardener-maintainers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os open-source
/kind enhancement

**What this PR does / why we need it**:

At STACKIT, we offer flatcar as the primary OS for worker nodes. Hence, we rely on this extension.
As other interested parties faced out CoreOS/flatcar in their environments, we probably have the highest stakes in keeping this extension up-to-date.
To simplify things, this PR adds two codeowners from STACKIT (particular persons are not set in stone).
This allows us to formally assume responsibility for this repository.

TODO:

- [x] https://github.com/gardener/gardener-extension-os-coreos/issues/97

**Which issue(s) this PR fixes**:

See https://gardener-cloud.slack.com/archives/C045DSWJZB9/p1711461148599709

**Special notes for your reviewer**:

I recall, that we cannot add contributors from outside SAP to the gardener org. With this, we cannot add STACKIT colleagues to the @gardener/gardener-extension-os-coreos-maintainers group.
If this has changed meanwhile, let me know and we can drop this PR and use the group instead.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
