### PR TITLE
[release-v1.19] Fix filepath collection for files with `ImageRef`

### DIFF
--- a/pkg/controller/operatingsystemconfig/coreos_reconcile.go
+++ b/pkg/controller/operatingsystemconfig/coreos_reconcile.go
@@ -108,6 +108,11 @@ func (a *actuator) cloudConfigFromOperatingSystemConfig(ctx context.Context, con
 
 	filePaths := make([]string, 0, len(config.Spec.Files))
 	for _, file := range config.Spec.Files {
+
+		if file.Content.ImageRef != nil {
+			continue
+		}
+
 		filePaths = append(filePaths, file.Path)
 		f := coreos.File{
 			Path: file.Path,


### PR DESCRIPTION
/area os
/kind bug

**What this PR does / why we need it**:

When the Gardener Node Agent for worker nodes is activated, either using the appropriate featuregate or using Gardener version v1.89.0 and above, the OperatingSystemConfig introduces some changes. One of these changes is, that files can now have a imageRef field. When this field is present, the file is extracted from a container image and not presented inline.

The reconcile is running into a panic in case of files with an imageRef field, because its trying to extract the inline data.
This small fix simply skips the content collection for these kind of files.

**Release note**:
```bugfix operator
Skipping filecontent collection for files with imageRef in OperatingSystemConfigs to prevent a panic.
```
