### PR TITLE
Add `11-exec_config.conf` to gardener-node-agent reconcile

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -109,7 +109,7 @@ mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/containerd --config /etc/containerd/config.toml'
+ExecStart=/usr/bin/containerd --config /etc/containerd/config.toml
 EOF
 chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 ` + writeFilesToDiskScript + `

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -109,7 +109,9 @@ mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/containerd --config /etc/containerd/config.toml
+# try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+# TODO: Remove torxc once flatcar LTS support has run out.
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'
 EOF
 chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
 ` + writeFilesToDiskScript + `
@@ -189,7 +191,7 @@ ExecStartPre=` + filePathKubeletCGroupDriverScript + `
 				Name: "11-exec_config.conf",
 				Content: `[Service]
 ExecStart=
-ExecStart=/usr/bin/containerd --config /etc/containerd/config.toml`,
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'`,
 			},
 		},
 	})

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -60,13 +60,13 @@ if [ ! -s /etc/containerd/config.toml ]; then
   containerd config default > /etc/containerd/config.toml
   chmod 0644 /etc/containerd/config.toml
 fi
+
 mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
-# TODO(MichaelEischer): remove this file once all flatcar versions that use torcx,
-# that is before 3815.2.0, have run out of support
 [Service]
 ExecStart=
 # try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+# TODO: Remove torxc once flatcar LTS support has run out.
 ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'
 EOF
 chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
@@ -203,6 +203,19 @@ ExecStartPre=/opt/bin/kubelet_cgroup_driver.sh
 `,
 						}},
 						FilePaths: []string{"/opt/bin/kubelet_cgroup_driver.sh"},
+					},
+					extensionsv1alpha1.Unit{
+						Name: "containerd.service",
+						DropIns: []extensionsv1alpha1.DropIn{
+							{
+								Name: "11-exec_config.conf",
+								Content: `[Service]
+ExecStart=
+# try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+# TODO: Remove torxc once flatcar LTS support has run out.
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'`,
+							},
+						},
 					},
 				))
 				Expect(extensionFiles).To(ConsistOf(

--- a/pkg/controller/operatingsystemconfig/templates/11-exec_config.conf
+++ b/pkg/controller/operatingsystemconfig/templates/11-exec_config.conf
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=
+# try to use containerd provided via torcx, but also falls back to /usr/bin/containerd provided via systemd-sysext
+# TODO: Remove torxc once flatcar LTS support has run out.
+ExecStart=/bin/bash -c 'PATH="/run/torcx/unpack/docker/bin:$PATH" containerd --config /etc/containerd/config.toml'


### PR DESCRIPTION
**How to categorize this PR?**
/area os
/kind enhancement

**What this PR does / why we need it**:

Prevent `11-exec_config.conf` from being accidentally deleted by gardener-node-agent.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `11-exec_config.conf` is now being reconciled by the `Provision` step of the gardener-node-agent
```
