### PR TITLE
Fix RBAC when deploying via gardener-operator

### DIFF
--- a/charts/gardener-extension-os-coreos/templates/rbac.yaml
+++ b/charts/gardener-extension-os-coreos/templates/rbac.yaml
@@ -76,14 +76,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gardener-extension-os-coreos
+  name: {{ include "coreos.name" . }}
   labels:
     {{- include "coreos.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener-extension-os-coreos
+  name: {{ include "coreos.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: gardener-extension-os-coreos
+  name: {{ include "coreos.name" . }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with the deployed `ClusterRoleBinding` for this extension when using the Gardener operator.

Currently the `ClusterRoleBinding` manifest assumes the Helm chart will always be named `gardener-extension-os-coreos`, which will break when deploying the extension through the Gardener operator.
The operator seems to change the chart name to: "os-coreos".

The templating introduced with this PR is in-line with other extensions, e.g. https://github.com/gardener/gardener-extension-provider-gcp/blob/master/charts/gardener-extension-provider-gcp/templates/rbac.yaml

**Special notes for your reviewer**:
The current workaround for this issue:
Set .Values.nameOverride to gardener-extension-os-coreos in the operator `Extension` manifest.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an RBAC issue when deploying this extension through the Gardener operator.
```
