### PR TITLE
Fix head-update gh action

### DIFF
--- a/.github/workflows/head-update.yaml
+++ b/.github/workflows/head-update.yaml
@@ -8,3 +8,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
+    permissions:
+      contents: read
+      packages: write
+      id-token: write


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind regression

**What this PR does / why we need it**:
Head update jobs for merged pull requests fail as required permissions are missing, see [failed workflow](https://github.com/gardener/gardener-extension-os-coreos/actions/runs/17035112731)



