### PR TITLE
fix: required permissions for build & release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,9 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
     with:
       mode: ${{ inputs.mode }}
+    permissions:
+      contents: read
+      pull-requests: write
 
   oci-images:
     name: Build OCI-Images
@@ -25,6 +28,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
+    secrets: inherit
     uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
     with:
       name: gardener-extension-os-coreos
@@ -52,6 +57,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
     uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@master
     with:
       name: os-coreos

--- a/.github/workflows/head-update.yaml
+++ b/.github/workflows/head-update.yaml
@@ -12,3 +12,4 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+      pull-requests: write
     with:
       mode: release
 
@@ -22,6 +27,10 @@ jobs:
     needs:
       - build
     secrets: inherit
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind regression

**What this PR does / why we need it**:

Should potentially fix the permission problem in the GH Workflows. (Needs to be verified)
I just looked at https://github.com/gardener/gardener-extension-provider-aws/pull/1453 and https://github.com/gardener/gardener-extension-provider-equinix-metal/pull/398

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
