### PR TITLE
Remove docker 🐳

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ status:
       namespace: default
   command: /usr/bin/coreos-cloudinit -from-file=<path>
   units:
-  - docker-monitor.service
+  - containerd-monitor.service
   - kubelet-monitor.service
   - kubelet.service
 ```

--- a/example/40-operatingsystemconfig.yaml
+++ b/example/40-operatingsystemconfig.yaml
@@ -6,20 +6,6 @@ metadata:
   namespace: default
 spec:
   type: coreos
-  units:
-  - name: containerd-monitor.service
-    command: start
-    enable: true
-    content: |
-      [Unit]
-      Description=Containerd-monitor daemon
-      After=kubelet.service
-      [Install]
-      WantedBy=multi-user.target
-      [Service]
-      Restart=always
-      EnvironmentFile=/etc/environment
-      ExecStart=/opt/bin/health-monitor container-runtime
   files:
   - path: /var/lib/example/file.txt
     permissions: 0644

--- a/example/40-operatingsystemconfig.yaml
+++ b/example/40-operatingsystemconfig.yaml
@@ -7,25 +7,19 @@ metadata:
 spec:
   type: coreos
   units:
-  - name: docker.service
-    dropIns:
-    - name: 10-docker-opts.conf
-      content: |
-        [Service]
-        Environment="DOCKER_OPTS=--log-opt max-size=60m --log-opt max-file=3"
-  - name: docker-monitor.service
+  - name: containerd-monitor.service
     command: start
     enable: true
     content: |
       [Unit]
-      Description=Docker-monitor daemon
+      Description=Containerd-monitor daemon
       After=kubelet.service
       [Install]
       WantedBy=multi-user.target
       [Service]
       Restart=always
       EnvironmentFile=/etc/environment
-      ExecStart=/opt/bin/health-monitor docker
+      ExecStart=/opt/bin/health-monitor container-runtime
   files:
   - path: /var/lib/example/file.txt
     permissions: 0644

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -196,10 +196,18 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 		}},
 	})
 
-	// Enable docker (present on Flatcar alongside containerd).
-	cfg.Systemd.Units = append(cfg.Systemd.Units, igntypes.Unit{
-		Name:    "docker.service",
-		Enabled: ptr.To(true),
+	// Remove the docker sysext image shipped by Flatcar. We only use containerd,
+	// so the docker extension is neutralized by linking its image to /dev/null,
+	// which prevents it from being loaded at boot.
+	// See https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar
+	cfg.Storage.Links = append(cfg.Storage.Links, igntypes.Link{
+		Node: igntypes.Node{
+			Path:      "/etc/extensions/docker-flatcar.raw",
+			Overwrite: ptr.To(true),
+		},
+		LinkEmbedded1: igntypes.LinkEmbedded1{
+			Target: ptr.To("/dev/null"),
+		},
 	})
 
 	// Convert units from the OSC spec.

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -43,6 +43,11 @@ type ignitionTestConfig struct {
 			} `json:"contents"`
 			Mode *int `json:"mode"`
 		} `json:"files"`
+		Links []struct {
+			Path      string  `json:"path"`
+			Target    *string `json:"target"`
+			Overwrite *bool   `json:"overwrite"`
+		} `json:"links"`
 	} `json:"storage"`
 	Systemd struct {
 		Units []struct {
@@ -144,9 +149,22 @@ var _ = Describe("Actuator", func() {
 				Expect(unitNames).To(ContainElements(
 					"containerd-setup.service",
 					"containerd.service",
-					"docker.service",
 					"some-unit.service",
 				))
+
+				By("not enabling docker, since only containerd is used")
+				Expect(unitNames).NotTo(ContainElement("docker.service"))
+
+				By("removing the Flatcar docker sysext image by linking it to /dev/null")
+				found := false
+				for _, l := range ign.Storage.Links {
+					if l.Path == "/etc/extensions/docker-flatcar.raw" {
+						found = true
+						Expect(l.Target).To(Equal(ptr.To("/dev/null")))
+						Expect(l.Overwrite).To(Equal(ptr.To(true)))
+					}
+				}
+				Expect(found).To(BeTrue(), "expected a link removing the docker sysext image")
 
 				By("enabling the containerd-setup unit")
 				for _, u := range ign.Systemd.Units {

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -156,15 +156,11 @@ var _ = Describe("Actuator", func() {
 				Expect(unitNames).NotTo(ContainElement("docker.service"))
 
 				By("removing the Flatcar docker sysext image by linking it to /dev/null")
-				found := false
-				for _, l := range ign.Storage.Links {
-					if l.Path == "/etc/extensions/docker-flatcar.raw" {
-						found = true
-						Expect(l.Target).To(Equal(ptr.To("/dev/null")))
-						Expect(l.Overwrite).To(Equal(ptr.To(true)))
-					}
-				}
-				Expect(found).To(BeTrue(), "expected a link removing the docker sysext image")
+				Expect(ign.Storage.Links).To(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/extensions/docker-flatcar.raw"),
+					HaveField("Target", ptr.To("/dev/null")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link removing the docker sysext image")
 
 				By("enabling the containerd-setup unit")
 				for _, u := range ign.Systemd.Units {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
Kubernetes does not use Docker anymore, therefore we remove it.
Having docker installed and enabled is a security risk.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-os-coreos/issues/151

**Special notes for your reviewer**:
Here is how I tested this feature:
```bash
shoot--ondemand--k6wpsa3p9i-worker-s3ks3-z1-74c6b-5982h / # systemctl status docker
Unit docker.service could not be found.
shoot--ondemand--k6wpsa3p9i-worker-s3ks3-z1-74c6b-5982h / # systemctl status containerd
● containerd.service - containerd container runtime
     Loaded: loaded (/usr/lib/systemd/system/containerd.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/containerd.service.d
             └─11-exec_config.conf, 30-env_config.conf
     Active: active (running) since Fri 2026-06-12 12:37:49 UTC; 12min ago
 Invocation: 407d5fab6ac349068d968315a4be76da
       Docs: https://containerd.io
   Main PID: 2452 (containerd)
      Tasks: 242
     Memory: 2.6G (peak: 2.6G)
        CPU: 46.078s
...
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
