### PR TITLE
Mask all update related services

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -4,6 +4,17 @@ The [`core.gardener.cloud/v1beta1.Shoot` resource](https://github.com/gardener/g
 
 In this document we describe how this configuration looks like and under which circumstances your attention may be required.
 
+## Disabled OS services
+
+During node provisioning, this extension disables and removes the following Flatcar/CoreOS components, as they are not needed in a Gardener-managed cluster:
+
+- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot.
+- **update-engine**: Automatic OS updates are not desired, since node updates are managed by Gardener (e.g. via machine image version updates). The unit is masked by linking `/etc/systemd/system/update-engine.service` to `/dev/null`.
+- **locksmithd**: The reboot manager for update-engine is not needed without automatic OS updates. The unit is masked by linking `/etc/systemd/system/locksmithd.service` to `/dev/null`.
+- **systemd-sysupdate**: The newer systemd-based update mechanism would periodically check for updates and even reboot the node automatically. Both `systemd-sysupdate.timer` and `systemd-sysupdate-reboot.timer` are masked by linking them to `/dev/null` under `/etc/systemd/system/`.
+
+Note that simply disabling these units would not be sufficient: Flatcar ships vendor "wants" symlinks under the read-only `/usr/lib/systemd/system` hierarchy, which pull the units in on every boot regardless of their enablement state. Masking via `/etc` (which takes precedence over `/usr`) is reboot-safe.
+
 ## AWS VPC settings for CoreOS workers
 
 Gardener allows you to create CoreOS based worker nodes by:

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -196,12 +196,7 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 		}},
 	})
 
-	// Remove the docker sysext image shipped by Flatcar. We only use containerd,
-	// so the docker extension is neutralized by linking its image to /dev/null,
-	// which prevents it from being loaded at boot.
-	// See https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar
-	//
-	// Additionally, mask update-engine.service and locksmithd.service by linking
+	// Mask update-engine.service and locksmithd.service by linking
 	// them to /dev/null. Automatic OS updates (update-engine) and the associated
 	// reboot manager (locksmithd) are not desired, since node updates are managed
 	// by Gardener (e.g. via machine image version updates).
@@ -231,6 +226,11 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 		})
 	}
 
+	// Remove the docker sysext image shipped by Flatcar. We only use containerd,
+	// so the docker extension is neutralized by linking its image to /dev/null,
+	// which prevents it from being loaded at boot.
+	// See https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar
+	//
 	cfg.Storage.Links = append(cfg.Storage.Links,
 		igntypes.Link{
 			Node: igntypes.Node{

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -200,15 +200,47 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 	// so the docker extension is neutralized by linking its image to /dev/null,
 	// which prevents it from being loaded at boot.
 	// See https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar
-	cfg.Storage.Links = append(cfg.Storage.Links, igntypes.Link{
-		Node: igntypes.Node{
-			Path:      "/etc/extensions/docker-flatcar.raw",
-			Overwrite: ptr.To(true),
-		},
-		LinkEmbedded1: igntypes.LinkEmbedded1{
-			Target: ptr.To("/dev/null"),
-		},
-	})
+	//
+	// Additionally, mask update-engine.service and locksmithd.service by linking
+	// them to /dev/null. Automatic OS updates (update-engine) and the associated
+	// reboot manager (locksmithd) are not desired, since node updates are managed
+	// by Gardener (e.g. via machine image version updates).
+	//
+	// The same applies to the newer systemd-sysupdate mechanism: its timers would
+	// periodically check for updates and even reboot the node automatically
+	// (systemd-sysupdate-reboot.timer), so they are masked as well.
+	//
+	// Note that simply disabling these units is not sufficient: Flatcar ships
+	// vendor "wants" symlinks under /usr/lib/systemd/system, which is read-only
+	// and pulls the units in on every boot regardless of their enablement state.
+	// Masking via /etc (which takes precedence over /usr) is reboot-safe.
+	for _, unitToMask := range []string{
+		"update-engine.service",
+		"locksmithd.service",
+		"systemd-sysupdate.timer",
+		"systemd-sysupdate-reboot.timer",
+	} {
+		cfg.Storage.Links = append(cfg.Storage.Links, igntypes.Link{
+			Node: igntypes.Node{
+				Path:      "/etc/systemd/system/" + unitToMask,
+				Overwrite: ptr.To(true),
+			},
+			LinkEmbedded1: igntypes.LinkEmbedded1{
+				Target: ptr.To("/dev/null"),
+			},
+		})
+	}
+
+	cfg.Storage.Links = append(cfg.Storage.Links,
+		igntypes.Link{
+			Node: igntypes.Node{
+				Path:      "/etc/extensions/docker-flatcar.raw",
+				Overwrite: ptr.To(true),
+			},
+			LinkEmbedded1: igntypes.LinkEmbedded1{
+				Target: ptr.To("/dev/null"),
+			},
+		})
 
 	// Convert units from the OSC spec.
 	for _, unit := range osc.Spec.Units {

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -162,6 +162,40 @@ var _ = Describe("Actuator", func() {
 					HaveField("Overwrite", ptr.To(true)),
 				)), "expected a link removing the docker sysext image")
 
+				By("masking update-engine.service by linking it to /dev/null")
+				Expect(ign.Storage.Links).To(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/systemd/system/update-engine.service"),
+					HaveField("Target", ptr.To("/dev/null")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link masking update-engine.service")
+
+				By("masking locksmithd.service by linking it to /dev/null")
+				Expect(ign.Storage.Links).To(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/systemd/system/locksmithd.service"),
+					HaveField("Target", ptr.To("/dev/null")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link masking locksmithd.service")
+
+				By("masking the systemd-sysupdate timers by linking them to /dev/null")
+				Expect(ign.Storage.Links).To(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/systemd/system/systemd-sysupdate.timer"),
+					HaveField("Target", ptr.To("/dev/null")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link masking systemd-sysupdate.timer")
+				Expect(ign.Storage.Links).To(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/systemd/system/systemd-sysupdate-reboot.timer"),
+					HaveField("Target", ptr.To("/dev/null")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link masking systemd-sysupdate-reboot.timer")
+
+				By("not enabling update-engine, locksmithd, and systemd-sysupdate, since OS updates are managed by Gardener")
+				Expect(unitNames).NotTo(ContainElements(
+					"update-engine.service",
+					"locksmithd.service",
+					"systemd-sysupdate.timer",
+					"systemd-sysupdate-reboot.timer",
+				))
+
 				By("enabling the containerd-setup unit")
 				for _, u := range ign.Systemd.Units {
 					if u.Name == "containerd-setup.service" {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind bug

**What this PR does / why we need it**:
This PR masks all update-related services (`update-engine.service`, `locksmithd.service`, `systemd-sysupdate.timer`, and `systemd-sysupdate-reboot.timer`) during node provisioning by linking them to `/dev/null` under `/etc/systemd/system/`.

Automatic OS updates are not desired on Gardener-managed nodes, since node updates are managed by Gardener itself (e.g., via machine image version updates). So far, these services were only stopped and disabled via the reconcile OSC (`Command: stop`, `Enable: false`). This is not sufficient:

- Flatcar ships vendor "wants" symlinks under the read-only `/usr/lib/systemd/system` hierarchy, which pull the units in on **every boot regardless of their enablement state**. Even units reported as `disabled; preset: disabled` are started again.
- The `gardener-node-agent` only executes unit commands when the OSC changes. After a node reboot, the units are running again and are never stopped until the next OSC change.
- When the next OSC change eventually stops `update-engine.service`, it exits with a non-zero exit code on `SIGTERM`, leaving the unit in a `failed` state ("Failed Units: 1" in the MOTD) and triggering failing health checks.
- With `locksmithd` running with `strategy="reboot"`, nodes could in theory even be rebooted outside of Gardener's control.

Masking via `/etc` (which takes precedence over `/usr`) neutralizes the vendor "wants" symlinks and is reboot-safe: the units never start in the first place.

The `systemd-sysupdate` timers are masked as well, since the newer systemd-based update mechanism would periodically check for updates and even reboot the node automatically (`systemd-sysupdate-reboot.timer`).


**Which issue(s) this PR fixes**:
None created

**Special notes for your reviewer**:
Masking only applies to newly provisioned nodes (Ignition runs on first boot only). Existing nodes still rely on the stop/disable commands in the reconcile OSC, which remain in place. Re-asserting the stopped state after a node reboot on existing nodes requires a fix in the `gardener-node-agent` (gardener/gardener), which is addressed separately.


This is the status of the services without the fix before a node reboot
```bash
❯ k node-shell shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4
spawning "nsenter-4fo324" on "shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4"
Update Strategy: No Reboots
Failed Units: 1
  update-engine.service
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 / # systemctl status locksmithd.service
○ locksmithd.service - Cluster reboot manager
     Loaded: loaded (/usr/lib/systemd/system/locksmithd.service; disabled; preset: disabled)
     Active: inactive (dead) since Fri 2026-07-17 08:14:58 UTC; 13min ago
   Duration: 1min 17.092s
 Invocation: a722fcca839840eca7c74f224cd7c764
   Main PID: 1806 (code=exited, status=0/SUCCESS)
   Mem peak: 12.3M
        CPU: 13ms

Jul 17 08:13:41 shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 systemd[1]: Started locksmithd.service - Cluster reboot manager.
Jul 17 08:13:41 shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 locksmithd[1806]: locksmithd starting currentOperation="UPDATE_STATUS_IDLE" strategy="reboot"
Jul 17 08:14:58 shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 systemd[1]: Stopping locksmithd.service - Cluster reboot manager...
Jul 17 08:14:58 shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 locksmithd[1806]: Received interrupt/termination signal - locksmithd is exiting.
Jul 17 08:14:58 shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 systemd[1]: locksmithd.service: Deactivated successfully.
Jul 17 08:14:58 shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 systemd[1]: Stopped locksmithd.service - Cluster reboot manager.
shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 / # systemctl status update-engine.service
× update-engine.service - Update Engine
     Loaded: loaded (/usr/lib/systemd/system/update-engine.service; disabled; preset: disabled)
     Active: failed (Result: exit-code) since Fri 2026-07-17 08:14:58 UTC; 13min ago
   Duration: 1min 17.129s
 Invocation: c25cde0f3f4b414ba37e0951c4983c0f
   Main PID: 1757 (code=exited, status=1/FAILURE)
   Mem peak: 3.8M
        CPU: 30ms

...
```

This is the status of the services without the fix after a node reboot
```bash
❯ k node-shell shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4
spawning "nsenter-nctpjk" on "shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4"
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 / # systemctl status update-engine.service
● update-engine.service - Update Engine
     Loaded: loaded (/usr/lib/systemd/system/update-engine.service; disabled; preset: disabled)
     Active: active (running) since Fri 2026-07-17 08:30:33 UTC; 9min ago
 Invocation: 930abf4b2f1d44c6969ef9808b9913c1
   Main PID: 6381 (update_engine)
      Tasks: 1 (limit: 30770)
     Memory: 12.6M (peak: 13.6M)
        CPU: 50ms
     CGroup: /system.slice/update-engine.service
             └─6381 /usr/sbin/update_engine -foreground -logtostderr

...
shoot--ondemand--logrotate-worker-svam3-z1-5448b-t7fk4 / # systemctl status locksmithd.service
● locksmithd.service - Cluster reboot manager
     Loaded: loaded (/usr/lib/systemd/system/locksmithd.service; disabled; preset: disabled)
     Active: active (running) since Fri 2026-07-17 08:30:33 UTC; 9min ago
 Invocation: 596673463fa445cfa07579f19823572f
   Main PID: 6479 (locksmithd)
      Tasks: 5 (limit: 30770)
     Memory: 12.1M (high: 32M, available: 19.8M, peak: 12.5M)
        CPU: 13ms
     CGroup: /system.slice/locksmithd.service
             └─6479 /usr/lib/locksmith/locksmithd

...
```
This is the status of the services with the fix in place before **and** after a reboot of the node
```bash
❯ k node-shell shoot--ondemand--logrotate-worker-svam3-z1-5448b-kjwc7
spawning "nsenter-3sgyzd" on "shoot--ondemand--logrotate-worker-svam3-z1-5448b-kjwc7"
Update Strategy: No Reboots
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
shoot--ondemand--logrotate-worker-svam3-z1-5448b-kjwc7 / # systemctl status locksmithd.service
○ locksmithd.service
     Loaded: masked (Reason: Unit locksmithd.service is masked.)
     Active: inactive (dead)
shoot--ondemand--logrotate-worker-svam3-z1-5448b-kjwc7 / # systemctl status update-engine.service
○ update-engine.service
     Loaded: masked (Reason: Unit update-engine.service is masked.)
     Active: inactive (dead)
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The update-related services `update-engine.service`, `locksmithd.service`, `systemd-sysupdate.timer`, and `systemd-sysupdate-reboot.timer` are now masked (linked to `/dev/null`) during node provisioning. Previously, these units were only stopped/disabled, which Flatcar's vendor "wants" symlinks under `/usr` overrode on every reboot, causing update services to run again and leaving `update-engine.service` in a `failed` state after being stopped.
```
