### PR TITLE
Make systemd units `update-engine.service` and `locksmithd.service` no-ops

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -44,6 +44,8 @@ var customContainerdServiceOverride string
 const noopExecStartDropIn = `[Service]
 ExecStart=
 ExecStart=/bin/true
+Restart=
+Restart=no
 `
 
 var ntpConfigTemplate *template.Template

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -44,7 +44,6 @@ var customContainerdServiceOverride string
 const noopExecStartDropIn = `[Service]
 ExecStart=
 ExecStart=/bin/true
-Restart=
 Restart=no
 `
 

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -41,6 +41,11 @@ var ntpConfigTemplateContent string
 //go:embed templates/11-exec_config.conf
 var customContainerdServiceOverride string
 
+const noopExecStartDropIn = `[Service]
+ExecStart=
+ExecStart=/bin/true
+`
+
 var ntpConfigTemplate *template.Template
 var decoder runtime.Decoder
 
@@ -350,11 +355,22 @@ func (a *actuator) handleReconcileOSC(config *configv1alpha1.ExtensionConfig, _ 
 		err            error
 	)
 
-	// disable automatic updates
-	extensionUnits = append(extensionUnits,
-		extensionsv1alpha1.Unit{Name: "update-engine.service", Command: ptr.To(extensionsv1alpha1.CommandStop), Enable: ptr.To(false)},
-		extensionsv1alpha1.Unit{Name: "locksmithd.service", Command: ptr.To(extensionsv1alpha1.CommandStop), Enable: ptr.To(false)},
-	)
+	// Disable automatic updates. The Ignition provisioning flow masks these
+	// units by symlinking them to /dev/null, but that only applies to new
+	// nodes. For existing nodes we also override ExecStart to /bin/true so
+	// the units become no-ops.
+	for _, name := range []string{"update-engine.service", "locksmithd.service"} {
+		extensionUnits = append(extensionUnits,
+			extensionsv1alpha1.Unit{
+				Name:    name,
+				Command: new(extensionsv1alpha1.CommandStop),
+				Enable:  new(false),
+				DropIns: []extensionsv1alpha1.DropIn{{
+					Name:    "20-noop-execstart.conf",
+					Content: noopExecStartDropIn,
+				}},
+			})
+	}
 
 	if ptr.Deref(config.NTP.Enabled, true) {
 		if extensionUnits, extensionFiles, err = a.configureNTPDaemon(config, extensionUnits, extensionFiles); err != nil {

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -353,7 +353,6 @@ interface listen dev2
 							Content: `[Service]
 ExecStart=
 ExecStart=/bin/true
-Restart=
 Restart=no
 `,
 						}},
@@ -367,7 +366,6 @@ Restart=no
 							Content: `[Service]
 ExecStart=
 ExecStart=/bin/true
-Restart=
 Restart=no
 `,
 						}},

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -353,6 +353,8 @@ interface listen dev2
 							Content: `[Service]
 ExecStart=
 ExecStart=/bin/true
+Restart=
+Restart=no
 `,
 						}},
 					},
@@ -365,6 +367,8 @@ ExecStart=/bin/true
 							Content: `[Service]
 ExecStart=
 ExecStart=/bin/true
+Restart=
+Restart=no
 `,
 						}},
 					},

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -344,8 +344,30 @@ interface listen dev2
 				Expect(extensionUnits).To(ConsistOf(
 					extensionsv1alpha1.Unit{Name: "systemd-timesyncd.service", Command: ptr.To(extensionsv1alpha1.CommandStart), Enable: ptr.To(true)},
 					extensionsv1alpha1.Unit{Name: "ntpd.service", Command: ptr.To(extensionsv1alpha1.CommandStop), Enable: ptr.To(false)},
-					extensionsv1alpha1.Unit{Name: "update-engine.service", Command: ptr.To(extensionsv1alpha1.CommandStop), Enable: ptr.To(false)},
-					extensionsv1alpha1.Unit{Name: "locksmithd.service", Command: ptr.To(extensionsv1alpha1.CommandStop), Enable: ptr.To(false)},
+					extensionsv1alpha1.Unit{
+						Name:    "update-engine.service",
+						Command: new(extensionsv1alpha1.CommandStop),
+						Enable:  new(false),
+						DropIns: []extensionsv1alpha1.DropIn{{
+							Name: "20-noop-execstart.conf",
+							Content: `[Service]
+ExecStart=
+ExecStart=/bin/true
+`,
+						}},
+					},
+					extensionsv1alpha1.Unit{
+						Name:    "locksmithd.service",
+						Command: new(extensionsv1alpha1.CommandStop),
+						Enable:  new(false),
+						DropIns: []extensionsv1alpha1.DropIn{{
+							Name: "20-noop-execstart.conf",
+							Content: `[Service]
+ExecStart=
+ExecStart=/bin/true
+`,
+						}},
+					},
 					extensionsv1alpha1.Unit{
 						Name: "kubelet.service",
 						DropIns: []extensionsv1alpha1.DropIn{{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind enhancement

**What this PR does / why we need it**:

This PR introduces drop-ins for the systemd units `update-engine.service` and `locksmithd.service` that make their `ExecStart` a no-op. As a follow-up for https://github.com/gardener/gardener-extension-os-coreos/pull/297 we aim to target existing nodes with this change. The masking added in that PR only applies at first boot via Ignition, so on existing nodes the two systemd units can still be started after a node reboot. With this drop-in they become no-ops even if that happens.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Turns `update-engine.service` and `locksmithd.service` into no-ops on existing worker nodes via an `ExecStart` drop-in.
```
