### PR TITLE
Add config option for enable of docker

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -8,7 +8,7 @@ In this document we describe how this configuration looks like and under which c
 
 During node provisioning, this extension disables and removes the following Flatcar/CoreOS components, as they are not needed in a Gardener-managed cluster:
 
-- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot.
+- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot. This can be disabled by setting `DisableDocker` to false in the extension.
 - **update-engine**: Automatic OS updates are not desired, since node updates are managed by Gardener (e.g. via machine image version updates). The unit is masked by linking `/etc/systemd/system/update-engine.service` to `/dev/null`.
 - **locksmithd**: The reboot manager for update-engine is not needed without automatic OS updates. The unit is masked by linking `/etc/systemd/system/locksmithd.service` to `/dev/null`.
 - **systemd-sysupdate**: The newer systemd-based update mechanism would periodically check for updates and even reboot the node automatically. Both `systemd-sysupdate.timer` and `systemd-sysupdate-reboot.timer` are masked by linking them to `/dev/null` under `/etc/systemd/system/`.

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -8,7 +8,7 @@ In this document we describe how this configuration looks like and under which c
 
 During node provisioning, this extension disables and removes the following Flatcar/CoreOS components, as they are not needed in a Gardener-managed cluster:
 
-- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot. Docker can be enabled by setting `Enableocker` to true in the extension config or the shoot `providerConfig` of the image.
+- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot. Docker can be enabled by setting `EnableDocker` to true in the extension config or the shoot `providerConfig` of the image.
 - **update-engine**: Automatic OS updates are not desired, since node updates are managed by Gardener (e.g. via machine image version updates). The unit is masked by linking `/etc/systemd/system/update-engine.service` to `/dev/null`.
 - **locksmithd**: The reboot manager for update-engine is not needed without automatic OS updates. The unit is masked by linking `/etc/systemd/system/locksmithd.service` to `/dev/null`.
 - **systemd-sysupdate**: The newer systemd-based update mechanism would periodically check for updates and even reboot the node automatically. Both `systemd-sysupdate.timer` and `systemd-sysupdate-reboot.timer` are masked by linking them to `/dev/null` under `/etc/systemd/system/`.

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -8,7 +8,7 @@ In this document we describe how this configuration looks like and under which c
 
 During node provisioning, this extension disables and removes the following Flatcar/CoreOS components, as they are not needed in a Gardener-managed cluster:
 
-- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot. This can be disabled by setting `DisableDocker` to false in the extension.
+- **Docker**: Only `containerd` is used as the container runtime. The Flatcar docker sysext image is removed by linking `/etc/extensions/docker-flatcar.raw` to `/dev/null`, so it is not loaded at boot. Docker can be enabled by setting `Enableocker` to true in the extension config or the shoot `providerConfig` of the image.
 - **update-engine**: Automatic OS updates are not desired, since node updates are managed by Gardener (e.g. via machine image version updates). The unit is masked by linking `/etc/systemd/system/update-engine.service` to `/dev/null`.
 - **locksmithd**: The reboot manager for update-engine is not needed without automatic OS updates. The unit is masked by linking `/etc/systemd/system/locksmithd.service` to `/dev/null`.
 - **systemd-sysupdate**: The newer systemd-based update mechanism would periodically check for updates and even reboot the node automatically. Both `systemd-sysupdate.timer` and `systemd-sysupdate-reboot.timer` are masked by linking them to `/dev/null` under `/etc/systemd/system/`.

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -43,14 +43,14 @@ ExtensionConfig is the configuration for the os-coreos extension.
 
 <tr>
 <td>
-<code>disableDocker</code></br>
+<code>enableDocker</code></br>
 <em>
 boolean
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>DisableDocker specifies if docker should be removed from the nodes.<br />Defaults to true, as everything is done by containerd.</p>
+<p>EnableDocker specifies if docker should be available on the nodes.<br />Defaults to false, as docker is only need for special use-cases.</p>
 </td>
 </tr>
 <tr>

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -43,6 +43,18 @@ ExtensionConfig is the configuration for the os-coreos extension.
 
 <tr>
 <td>
+<code>disableDocker</code></br>
+<em>
+boolean
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableDocker specifies if docker should be removed from the nodes.<br />Defaults to true, as everything is done by containerd.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ntp</code></br>
 <em>
 <a href="#ntpconfig">NTPConfig</a>

--- a/pkg/controller/config/v1alpha1/defaults.go
+++ b/pkg/controller/config/v1alpha1/defaults.go
@@ -13,6 +13,9 @@ func SetDefaults_ExtensionConfig(obj *ExtensionConfig) {
 	if obj.NTP == nil {
 		obj.NTP = &NTPConfig{}
 	}
+	if obj.DisableDocker == nil {
+		obj.DisableDocker = new(true)
+	}
 }
 
 func SetDefaults_NTPConfig(obj *NTPConfig) {

--- a/pkg/controller/config/v1alpha1/defaults.go
+++ b/pkg/controller/config/v1alpha1/defaults.go
@@ -13,9 +13,6 @@ func SetDefaults_ExtensionConfig(obj *ExtensionConfig) {
 	if obj.NTP == nil {
 		obj.NTP = &NTPConfig{}
 	}
-	if obj.DisableDocker == nil {
-		obj.DisableDocker = new(true)
-	}
 }
 
 func SetDefaults_NTPConfig(obj *NTPConfig) {

--- a/pkg/controller/config/v1alpha1/types.go
+++ b/pkg/controller/config/v1alpha1/types.go
@@ -17,6 +17,10 @@ const (
 type ExtensionConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// DisableDocker specifies if docker should be removed from the nodes.
+	// Defaults to true, as everything is done by containerd.
+	// +optional
+	DisableDocker *bool `json:"disableDocker"`
 	// NTP to configure either systemd-timesyncd or ntpd
 	// +optional
 	NTP *NTPConfig `json:"ntp,omitempty"`

--- a/pkg/controller/config/v1alpha1/types.go
+++ b/pkg/controller/config/v1alpha1/types.go
@@ -17,10 +17,10 @@ const (
 type ExtensionConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// DisableDocker specifies if docker should be removed from the nodes.
-	// Defaults to true, as everything is done by containerd.
+	// EnableDocker specifies if docker should be available on the nodes.
+	// Defaults to false, as docker is only need for special use-cases.
 	// +optional
-	DisableDocker *bool `json:"disableDocker"`
+	EnableDocker *bool `json:"enableDocker,omitempty"`
 	// NTP to configure either systemd-timesyncd or ntpd
 	// +optional
 	NTP *NTPConfig `json:"ntp,omitempty"`

--- a/pkg/controller/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controller/config/v1alpha1/zz_generated.deepcopy.go
@@ -17,8 +17,8 @@ import (
 func (in *ExtensionConfig) DeepCopyInto(out *ExtensionConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.DisableDocker != nil {
-		in, out := &in.DisableDocker, &out.DisableDocker
+	if in.EnableDocker != nil {
+		in, out := &in.EnableDocker, &out.EnableDocker
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/controller/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controller/config/v1alpha1/zz_generated.deepcopy.go
@@ -17,6 +17,11 @@ import (
 func (in *ExtensionConfig) DeepCopyInto(out *ExtensionConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.DisableDocker != nil {
+		in, out := &in.DisableDocker, &out.DisableDocker
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NTP != nil {
 		in, out := &in.NTP, &out.NTP
 		*out = new(NTPConfig)

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -91,8 +91,8 @@ func (a *actuator) GetAndMergeProviderConfiguration(osc *extensionsv1alpha1.Oper
 		config.NTP = shootExtensionConfig.NTP
 	}
 
-	if shootExtensionConfig.DisableDocker != nil {
-		config.DisableDocker = shootExtensionConfig.DisableDocker
+	if shootExtensionConfig.EnableDocker != nil {
+		config.EnableDocker = shootExtensionConfig.EnableDocker
 	}
 
 	return config, nil
@@ -241,7 +241,7 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, config *configv1alpha
 	// which prevents it from being loaded at boot.
 	// See https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar
 	//
-	if config.DisableDocker != nil && *config.DisableDocker {
+	if !ptr.Deref(config.EnableDocker, false) {
 		cfg.Storage.Links = append(cfg.Storage.Links,
 			igntypes.Link{
 				Node: igntypes.Node{

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -91,6 +91,10 @@ func (a *actuator) GetAndMergeProviderConfiguration(osc *extensionsv1alpha1.Oper
 		config.NTP = shootExtensionConfig.NTP
 	}
 
+	if shootExtensionConfig.DisableDocker != nil {
+		config.DisableDocker = shootExtensionConfig.DisableDocker
+	}
+
 	return config, nil
 }
 
@@ -111,7 +115,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, osc *extensions
 
 	switch purpose := osc.Spec.Purpose; purpose {
 	case extensionsv1alpha1.OperatingSystemConfigPurposeProvision:
-		userData, err := a.handleProvisionOSC(ctx, osc)
+		userData, err := a.handleProvisionOSC(ctx, config, osc)
 		return []byte(userData), nil, nil, nil, err
 
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
@@ -145,7 +149,7 @@ var containerdTemplateContent string
 //go:embed templates/containerd-setup.service
 var containerdSetupUnitContent string
 
-func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig) (string, error) {
+func (a *actuator) handleProvisionOSC(ctx context.Context, config *configv1alpha1.ExtensionConfig, osc *extensionsv1alpha1.OperatingSystemConfig) (string, error) {
 	cfg := igntypes.Config{
 		Ignition: igntypes.Ignition{
 			Version: igntypes.MaxVersion.String(),
@@ -237,16 +241,18 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 	// which prevents it from being loaded at boot.
 	// See https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar
 	//
-	cfg.Storage.Links = append(cfg.Storage.Links,
-		igntypes.Link{
-			Node: igntypes.Node{
-				Path:      "/etc/extensions/docker-flatcar.raw",
-				Overwrite: ptr.To(true),
-			},
-			LinkEmbedded1: igntypes.LinkEmbedded1{
-				Target: ptr.To("/dev/null"),
-			},
-		})
+	if config.DisableDocker != nil && *config.DisableDocker {
+		cfg.Storage.Links = append(cfg.Storage.Links,
+			igntypes.Link{
+				Node: igntypes.Node{
+					Path:      "/etc/extensions/docker-flatcar.raw",
+					Overwrite: ptr.To(true),
+				},
+				LinkEmbedded1: igntypes.LinkEmbedded1{
+					Target: ptr.To("/dev/null"),
+				},
+			})
+	}
 
 	// Convert units from the OSC spec.
 	for _, unit := range osc.Spec.Units {

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -252,6 +252,11 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, config *configv1alpha
 					Target: ptr.To("/dev/null"),
 				},
 			})
+	} else {
+		cfg.Systemd.Units = append(cfg.Systemd.Units, igntypes.Unit{
+			Name:    "docker.service",
+			Enabled: ptr.To(true),
+		})
 	}
 
 	// Convert units from the OSC spec.

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -253,9 +253,21 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, config *configv1alpha
 				},
 			})
 	} else {
+		// To be able to run containers with restart policy always we need to create also a link.
+		// See https://www.flatcar.org/docs/latest/orchestrate/containers/getting-started-with-docker/#permanently-running-a-container
 		cfg.Systemd.Units = append(cfg.Systemd.Units, igntypes.Unit{
 			Name:    "docker.service",
 			Enabled: ptr.To(true),
+		})
+		cfg.Storage.Links = append(cfg.Storage.Links, igntypes.Link{
+			Node: igntypes.Node{
+				Path:      "/etc/systemd/system/multi-user.target.wants/docker.service",
+				Overwrite: ptr.To(true),
+			},
+			LinkEmbedded1: igntypes.LinkEmbedded1{
+				Target: ptr.To("/usr/lib/systemd/system/docker.service"),
+				Hard:   ptr.To(false),
+			},
 		})
 	}
 

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Actuator", func() {
 	},
 		Entry("no shoot config",
 			configv1alpha1.ExtensionConfig{
-				DisableDocker: new(true),
+				EnableDocker: new(false),
 				NTP: &configv1alpha1.NTPConfig{
 					Enabled: ptr.To(true),
 					Daemon:  configv1alpha1.SystemdTimesyncd,
@@ -102,7 +102,7 @@ var _ = Describe("Actuator", func() {
 			},
 			configv1alpha1.ExtensionConfig{},
 			configv1alpha1.ExtensionConfig{
-				DisableDocker: new(true),
+				EnableDocker: new(false),
 				NTP: &configv1alpha1.NTPConfig{
 					Enabled: ptr.To(true),
 					Daemon:  configv1alpha1.SystemdTimesyncd,
@@ -110,13 +110,13 @@ var _ = Describe("Actuator", func() {
 			}),
 		Entry("overwrite DisableDocker",
 			configv1alpha1.ExtensionConfig{
-				DisableDocker: new(true),
+				EnableDocker: new(true),
 			},
 			configv1alpha1.ExtensionConfig{
-				DisableDocker: new(false),
+				EnableDocker: new(false),
 			},
 			configv1alpha1.ExtensionConfig{
-				DisableDocker: new(false),
+				EnableDocker: new(false),
 			}),
 		Entry("overwrite ntp",
 			configv1alpha1.ExtensionConfig{
@@ -158,7 +158,6 @@ var _ = Describe("Actuator", func() {
 		mgr = test.FakeManager{Client: fakeClient}
 		extensionConfig := Config{
 			ExtensionConfig: &configv1alpha1.ExtensionConfig{
-				DisableDocker: new(true),
 				NTP: &configv1alpha1.NTPConfig{
 					Enabled: ptr.To(true),
 					Daemon:  configv1alpha1.SystemdTimesyncd,
@@ -301,10 +300,10 @@ var _ = Describe("Actuator", func() {
 				}
 			})
 
-			It("should override global defaults on a shoot by shoot basis and not disable docker", func() {
+			It("should override global defaults on a shoot by shoot basis and enable docker", func() {
 				// Shoot specific override via providerConfig
 				providerConfigData := configv1alpha1.ExtensionConfig{
-					DisableDocker: new(false),
+					EnableDocker: new(true),
 				}
 				providerConfigBuffer := new(bytes.Buffer)
 				err := encoder.Encode(&providerConfigData, providerConfigBuffer)

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package operatingsystemconfig_test
+package operatingsystemconfig
 
 import (
 	"bytes"
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	configv1alpha1 "github.com/gardener/gardener-extension-os-coreos/pkg/controller/config/v1alpha1"
-	. "github.com/gardener/gardener-extension-os-coreos/pkg/controller/operatingsystemconfig"
 )
 
 // ignitionTestConfig mirrors the Ignition v3 JSON structure for test assertions only.
@@ -64,6 +63,82 @@ type ignitionTestConfig struct {
 
 var _ = Describe("Actuator", func() {
 	var (
+		scheme  = runtime.NewScheme()
+		encoder runtime.Encoder
+	)
+
+	BeforeEach(func() {
+		runtimeutils.Must(configv1alpha1.AddToScheme(scheme))
+		encoder = serializer.NewCodecFactory(scheme).EncoderForVersion(&json.Serializer{}, configv1alpha1.SchemeGroupVersion)
+
+	})
+
+	DescribeTable("GetAndMergeProviderConfiguration", func(extensionConfig, shootConfig, expectedConfig configv1alpha1.ExtensionConfig) {
+		providerConfigBuffer := new(bytes.Buffer)
+		Expect(encoder.Encode(&shootConfig, providerConfigBuffer)).To(Succeed())
+		osc := &extensionsv1alpha1.OperatingSystemConfig{
+			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					ProviderConfig: &runtime.RawExtension{Raw: providerConfigBuffer.Bytes()},
+				},
+			},
+		}
+		a := &actuator{
+			extensionConfig: Config{&extensionConfig},
+		}
+		config, err := a.GetAndMergeProviderConfiguration(osc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config).ToNot(BeNil())
+		configv1alpha1.SetObjectDefaults_ExtensionConfig(&expectedConfig)
+		Expect(*config).To(Equal(expectedConfig))
+	},
+		Entry("no shoot config",
+			configv1alpha1.ExtensionConfig{
+				DisableDocker: new(true),
+				NTP: &configv1alpha1.NTPConfig{
+					Enabled: ptr.To(true),
+					Daemon:  configv1alpha1.SystemdTimesyncd,
+				},
+			},
+			configv1alpha1.ExtensionConfig{},
+			configv1alpha1.ExtensionConfig{
+				DisableDocker: new(true),
+				NTP: &configv1alpha1.NTPConfig{
+					Enabled: ptr.To(true),
+					Daemon:  configv1alpha1.SystemdTimesyncd,
+				},
+			}),
+		Entry("overwrite DisableDocker",
+			configv1alpha1.ExtensionConfig{
+				DisableDocker: new(true),
+			},
+			configv1alpha1.ExtensionConfig{
+				DisableDocker: new(false),
+			},
+			configv1alpha1.ExtensionConfig{
+				DisableDocker: new(false),
+			}),
+		Entry("overwrite ntp",
+			configv1alpha1.ExtensionConfig{
+				NTP: &configv1alpha1.NTPConfig{
+					Enabled: ptr.To(true),
+					Daemon:  configv1alpha1.SystemdTimesyncd,
+				}},
+			configv1alpha1.ExtensionConfig{
+				NTP: &configv1alpha1.NTPConfig{
+					Enabled: ptr.To(true),
+					Daemon:  configv1alpha1.NTPD,
+				}},
+			configv1alpha1.ExtensionConfig{
+				NTP: &configv1alpha1.NTPConfig{
+					Enabled: ptr.To(true),
+					Daemon:  configv1alpha1.NTPD,
+				}}),
+	)
+})
+
+var _ = Describe("Actuator", func() {
+	var (
 		ctx        = context.TODO()
 		log        = logr.Discard()
 		fakeClient client.Client
@@ -83,6 +158,7 @@ var _ = Describe("Actuator", func() {
 		mgr = test.FakeManager{Client: fakeClient}
 		extensionConfig := Config{
 			ExtensionConfig: &configv1alpha1.ExtensionConfig{
+				DisableDocker: new(true),
 				NTP: &configv1alpha1.NTPConfig{
 					Enabled: ptr.To(true),
 					Daemon:  configv1alpha1.SystemdTimesyncd,
@@ -223,6 +299,30 @@ var _ = Describe("Actuator", func() {
 						Expect(*u.Contents).To(ContainSubstring("[Unit]"))
 					}
 				}
+			})
+
+			It("should override global defaults on a shoot by shoot basis and not disable docker", func() {
+				// Shoot specific override via providerConfig
+				providerConfigData := configv1alpha1.ExtensionConfig{
+					DisableDocker: new(false),
+				}
+				providerConfigBuffer := new(bytes.Buffer)
+				err := encoder.Encode(&providerConfigData, providerConfigBuffer)
+				osc.Spec.ProviderConfig = &runtime.RawExtension{Raw: providerConfigBuffer.Bytes()}
+				defer DeferCleanup(func() {
+					osc.Spec.ProviderConfig = nil
+				})
+				Expect(err).NotTo(HaveOccurred())
+				userData, _, _, _, err := actuator.Reconcile(ctx, log, osc)
+				Expect(err).NotTo(HaveOccurred())
+
+				var ign ignitionTestConfig
+				Expect(stdjson.Unmarshal(userData, &ign)).To(Succeed())
+				Expect(ign.Storage.Links).ToNot(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/extensions/docker-flatcar.raw"),
+					HaveField("Target", ptr.To("/dev/null")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link removing the docker sysext image")
 			})
 		})
 	})

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -317,6 +317,13 @@ var _ = Describe("Actuator", func() {
 
 				var ign ignitionTestConfig
 				Expect(stdjson.Unmarshal(userData, &ign)).To(Succeed())
+
+				unitNames := make([]string, 0, len(ign.Systemd.Units))
+				for _, u := range ign.Systemd.Units {
+					unitNames = append(unitNames, u.Name)
+				}
+				Expect(unitNames).To(ContainElements("docker.service"))
+
 				Expect(ign.Storage.Links).ToNot(ContainElement(SatisfyAll(
 					HaveField("Path", "/etc/extensions/docker-flatcar.raw"),
 					HaveField("Target", ptr.To("/dev/null")),

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -318,11 +318,16 @@ var _ = Describe("Actuator", func() {
 				var ign ignitionTestConfig
 				Expect(stdjson.Unmarshal(userData, &ign)).To(Succeed())
 
-				unitNames := make([]string, 0, len(ign.Systemd.Units))
-				for _, u := range ign.Systemd.Units {
-					unitNames = append(unitNames, u.Name)
-				}
-				Expect(unitNames).To(ContainElements("docker.service"))
+				Expect(ign.Systemd.Units).To(ContainElement(SatisfyAll(
+					HaveField("Name", "docker.service"),
+					HaveField("Enabled", ptr.To(true)),
+				)), "check if docker.service is enabled in units")
+
+				Expect(ign.Storage.Links).To(ContainElement(SatisfyAll(
+					HaveField("Path", "/etc/systemd/system/multi-user.target.wants/docker.service"),
+					HaveField("Target", ptr.To("/usr/lib/systemd/system/docker.service")),
+					HaveField("Overwrite", ptr.To(true)),
+				)), "expected a link to enable the docker.service")
 
 				Expect(ign.Storage.Links).ToNot(ContainElement(SatisfyAll(
 					HaveField("Path", "/etc/extensions/docker-flatcar.raw"),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind enhancement
/cc @robinschneider 

/hold
I am still testing this.

**What this PR does / why we need it**:

With #290 we removed docker for all new servers. It is possible that some users require docker for their workload. This PR adds an config option to enable docker which defaults to false.

**Special notes for your reviewer**:

~~We also could name the config option differently, so we can have false as default? WDYT?~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add config `enableDocker` (extension config or image-`providerConfig` in shoot) to enable docker again if needed for workload in a cluster.
```
